### PR TITLE
Disable npm spinner

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function execNpmInstall(what, cwd, cb) {
     },
   };
 
-  var command = 'npm install ' + what;
+  var command = 'npm install --spin=false ' + what;
   debug(command);
   return exec(command, options, function(err, stdout, stderr) {
     debug('--npm install stdout--\n%s\n--npm install stderr--\n%s\n--end--',


### PR DESCRIPTION
The output is being buffered, so the longer the install takes the more
memory is consumed for no reason. Theoretically, a long enough install
will cause the parent process to run out of memory.

/to @bajtos 
