### PR TITLE
Bump ncp dependency to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "async": "^0.9.0",
     "debug": "^1.0.2",
     "fs-extra": "^0.10.0",
-    "ncp": "^0.6.0"
+    "ncp": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
ncp@1.0.0 is the first release to include AvianFlu/ncp#58, which is
necessary for our 0.11.x-pre based CI.

@bajtos after merging this and publishing (as 1.1.1, I'm guessing), loopback-workspace should start passing on CI for all our platforms without any further changes.
