### PR TITLE
Run `npm build .` after cached install

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "chai": "^1.9.1",
     "jshint": "^2.5.2",
-    "mocha": "^1.20.1"
+    "mocha": "^1.20.1",
+    "which": "^1.0.5"
   }
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,11 @@
 /*global describe, it, beforeEach */
+var exec = require('child_process').exec;
 var fs = require('fs-extra');
 var path = require('path');
+var which = require('which');
 var install = require('../');
+
+var debug = require('debug')('test');
 
 var expect = require('chai').expect;
 
@@ -41,6 +45,45 @@ describe('cached install', function() {
         if (err) return done(err);
         expectDebugVersionInstalled('0.8.0+mod');
         done();
+      });
+    });
+  });
+
+  it('creates .bin links when installing from cache', function(done) {
+    // This test needs to install a package that is not already in PATH
+    // mkdirp is a good candidate, let's verify it's not already there
+    try {
+      var mkdirpPath = which.sync('mkdirp');
+      return done(new Error('mkdir is already installed in ' + mkdirpPath));
+    } catch(err) {
+    }
+
+    var packageJson = {
+      scripts: {
+        test: 'mkdirp tested'
+      },
+      dependencies: {
+        mkdirp: '0.5.0'
+      }
+    };
+
+    givenPackage(packageJson);
+    install(SANDBOX, CACHE, function(err) {
+      if (err) return done(err);
+      resetSandboxSync();
+      givenPackage(packageJson);
+
+      // Install mkdirp from the cache
+      install(SANDBOX, CACHE, function(err) {
+        if (err) return done(err);
+        // Verify that `npm test` can call `mkdirp` in SANDBOX
+        debug('executing `npm test`');
+
+        exec('npm test', { cwd: SANDBOX }, function(err, stdout, stderr) {
+          debug('--npm test stdout--\n%s\n--npm test stderr--\n%s\n--end--',
+            stdout, stderr);
+          done(err);
+        });
       });
     });
   });


### PR DESCRIPTION
Before this change, `node_modules/.bin` was not populated when a module
was installed from the cache.

This change add a call of `npm build .` to let npm execute all necessary
post-install steps.

A side-effect of this change is that `preinstall`, `install` and
`postinstall` scripts are executed too.

/to @rmg please review
