### PR TITLE
Fix missing dependencies under npm@3

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function installPackage(appDir, cacheDir, name, version, cb) {
 }
 
 function execNpmInstall(what, cwd, cb) {
-  execNpmCommand('install --spin=false ' + what, cwd, cb);
+  execNpmCommand('install --spin=false --global-style ' + what, cwd, cb);
 }
 
 function execNpmCommand(commandWithArgs, cwd, cb) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "jshint": "^2.9.1-rc1",
-    "mocha": "^2.3.4",
-    "which": "^1.2.0"
+    "mocha": "^2.3.4"
   }
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -2,7 +2,6 @@
 var exec = require('child_process').exec;
 var fs = require('fs-extra');
 var path = require('path');
-var which = require('which');
 var install = require('../');
 
 var debug = require('debug')('test');
@@ -51,19 +50,21 @@ describe('cached install', function() {
 
   it('creates .bin links when installing from cache', function(done) {
     // This test needs to install a package that is not already in PATH
-    // mkdirp is a good candidate, let's verify it's not already there
+    // cowsay is a good candidate, let's verify it's not already there
     try {
-      var mkdirpPath = which.sync('mkdirp');
-      return done(new Error('mkdir is already installed in ' + mkdirpPath));
+      var cowsayPath = path.resolve(SANDBOX, 'node_modules', '.bin', 'cowsay');
+      if (fs.accessSync(cowsayPath) || fs.accessSync(cowsayPath + '.cmd')) {
+        return done(new Error('mkdir is already installed in ' + cowsayPath));
+      }
     } catch(err) {
     }
 
     var packageJson = {
       scripts: {
-        test: 'mkdirp tested'
+        test: './node_modules/.bin/cowsay tested'
       },
       dependencies: {
-        mkdirp: '0.5.0'
+        cowsay: '1.1.2'
       }
     };
 
@@ -73,10 +74,10 @@ describe('cached install', function() {
       resetSandboxSync();
       givenPackage(packageJson);
 
-      // Install mkdirp from the cache
+      // Install cowsay from the cache
       install(SANDBOX, CACHE, function(err) {
         if (err) return done(err);
-        // Verify that `npm test` can call `mkdirp` in SANDBOX
+        // Verify that `npm test` can call `cowsay` in SANDBOX
         debug('executing `npm test`');
 
         exec('npm test', { cwd: SANDBOX }, function(err, stdout, stderr) {


### PR DESCRIPTION
The scenario we need to test for is npm3's flattening behaviour, which
results in our 'cached' modules not containing any of their dependencies
like they do with npm@2. The use of cowsay here is because mkdirp is a
dependency of mocha, so both mkdirp and mkdirp's dependencies are
present in the module resolution path when we run the sandbox test. The
cowsay module depends on modules that are not used in the rest of
strong-cached-install, so there is no way for strong-cached-install's
dependencies to mask the problem.

By adding the --global-style flag we tell npm to treat 'npm install foo'
similar to a global install in that it installs all its dependencies
under foo's node_modules, which is what we really want for caching.

We also switch from relying on $PATH to referencing the .bin directory
directly because it removes a potential source of false positives from
the test command already being in the $PATH for unrelated reasons.