### PR TITLE
Pass all ENV to `npm` (fix for Windows)

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,13 +81,10 @@ function execNpmInstall(what, cwd, cb) {
 }
 
 function execNpmCommand(commandWithArgs, cwd, cb) {
+  debug('NPM ENV', process.env);
+
   var options = {
     cwd: cwd,
-    env: {
-      PATH: process.env.PATH,
-      HOME: process.env.HOME,
-      USERPROFILE: process.env.USERPROFILE,
-    },
   };
 
   var script = 'npm ' + commandWithArgs;


### PR DESCRIPTION
On Windows, some versions of npm use env var APPDATA to resolve path where to keep certain files. Before this change, we were passing only a subset of env properties to `npm`, APPDATA was not among them.

In this commit, we fix the issue by passing all env variables to npm.

As a side effect, this change also fixes strong-cached-install to honour npm env variables, e.g. `npm_config_registry`, set in the parent environment.

Fix #9 

@jannyhou @rmg please review