### PR TITLE
Fix installation of ^x.y.z versions on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
+  - "0.12"
+  - "4"
+  - "6"
+  - "7"
 notifications:
   email: false

--- a/index.js
+++ b/index.js
@@ -48,6 +48,16 @@ module.exports = function install(appDir, cacheDir, depTypes, cb) {
   }
 };
 
+module.exports.package = installPackage;
+
+/**
+ * Install a single package with a given version.
+ * @param {string} appDir Application's root directory.
+ * @param {string} cacheDir Directory where to keep cached files.
+ * @param {string} name Package name, e.g. "loopback"
+ * @param {string} version Version specifier, e.g. "2.5.0" or "^2.6.5"
+ * @param {function(Error=)} cb The callback.
+ */
 function installPackage(appDir, cacheDir, name, version, cb) {
   var quotedVersion = version.replace(/^\^/, 'caret-').replace(/^~/, 'tilde-');
   var cachePath = path.join(cacheDir, name, quotedVersion);
@@ -88,6 +98,13 @@ function execNpmCommand(commandWithArgs, cwd, cb) {
   };
 
   var script = 'npm ' + commandWithArgs;
+  if (/^win/.test(process.platform)) {
+    // On Windows, "^" is a reserved character that must be escaped as "^^"
+    // Strangely enough, we need to escape it twice, as if there were
+    // two CMD shells invoked under the hood
+    script = script.replace('^', '^^^^');
+  }
+
   debug(script);
   return exec(script, options, function(err, stdout, stderr) {
     debug('--npm stdout--\n%s\n--npm stderr--\n%s\n--end--',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "jshint": "^2.9.1-rc1",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "semver": "^5.3.0"
   }
 }


### PR DESCRIPTION
See https://github.com/strongloop/loopback-workspace/issues/416

I think this should fix most (if not all) issues we are observing on Windows, but I hadn't have time to verify that yet.

@superkhau and/or @deepakrkris please review